### PR TITLE
Support to NIE documents

### DIFF
--- a/app/services/carpetaciutada_handler.rb
+++ b/app/services/carpetaciutada_handler.rb
@@ -33,7 +33,7 @@ class CarpetaciutadaHandler < Decidim::AuthorizationHandler
   end
 
   def sanitize_document_number
-    document_number.to_i
+    document_number[0...-1]
   end
 
   def over_16


### PR DESCRIPTION
Remove just the verification letter, before this convert the string to an integer so the NIE documents return false always.