### PR TITLE
Fix ransack version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,8 @@ gem "uglifier", ">= 1.3.0"
 gem "virtus-multiparams"
 gem "wicked_pdf"
 
+gem "ransack", "2.1.1"
+
 group :development, :test do
   gem "byebug", platform: :mri
   gem "decidim-dev"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -570,8 +570,6 @@ GEM
     pg_search (2.3.0)
       activerecord (>= 4.2)
       activesupport (>= 4.2)
-    polyamorous (2.3.0)
-      activerecord (>= 5.0)
     powerpack (0.1.2)
     premailer (1.11.1)
       addressable
@@ -623,12 +621,11 @@ GEM
       thor (>= 0.19.0, < 2.0)
     rainbow (3.0.0)
     rake (12.3.3)
-    ransack (2.3.0)
+    ransack (2.1.1)
       actionpack (>= 5.0)
       activerecord (>= 5.0)
       activesupport (>= 5.0)
       i18n
-      polyamorous (= 2.3.0)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
@@ -823,6 +820,7 @@ DEPENDENCIES
   letter_opener_web (~> 1.3.0)
   listen (~> 3.1.0)
   puma (~> 3.0)
+  ransack (= 2.1.1)
   redis-namespace
   rspec-rails
   rubocop


### PR DESCRIPTION
This fix the missing method `polymorphic?` in ransack 2.3.0